### PR TITLE
Tracking improvements

### DIFF
--- a/src/DeepCopy/ArrayCopier.cs
+++ b/src/DeepCopy/ArrayCopier.cs
@@ -7,6 +7,7 @@ namespace DeepCopy
         internal static T[] CopyArrayRank1<T>(T[] originalArray, CopyContext context)
         {
             if (context.TryGetCopy(originalArray, out var existingCopy)) return (T[]) existingCopy;
+
             var length = originalArray.Length;
             var result = new T[length];
             context.RecordCopy(originalArray, result);
@@ -39,20 +40,22 @@ namespace DeepCopy
             var result = new T[lenI, lenJ];
             context.RecordCopy(originalArray, result);
             for (var i = 0; i < lenI; i++)
-            for (var j = 0; j < lenJ; j++)
             {
-                var original = originalArray[i, j];
-                if (original != null)
+                for (var j = 0; j < lenJ; j++)
                 {
-                    if (context.TryGetCopy(original, out var existingElement))
+                    var original = originalArray[i, j];
+                    if (original != null)
                     {
-                        result[i, j] = (T) existingElement;
-                    }
-                    else
-                    {
-                        var copy = CopierGenerator<T>.Copy(original, context);
-                        context.RecordCopy(original, copy);
-                        result[i, j] = copy;
+                        if (context.TryGetCopy(original, out var existingElement))
+                        {
+                            result[i, j] = (T) existingElement;
+                        }
+                        else
+                        {
+                            var copy = CopierGenerator<T>.Copy(original, context);
+                            context.RecordCopy(original, copy);
+                            result[i, j] = copy;
+                        }
                     }
                 }
             }

--- a/src/DeepCopy/ArrayCopier.cs
+++ b/src/DeepCopy/ArrayCopier.cs
@@ -4,7 +4,7 @@ namespace DeepCopy
 {
     internal static class ArrayCopier
     {
-        internal static T[] CopyArrayRank1<T>(T[] originalArray, CopyContext context) where T: class 
+        internal static T[] CopyArrayRank1<T>(T[] originalArray, CopyContext context)
         {
             if (context.TryGetCopy(originalArray, out var existingCopy)) return (T[]) existingCopy;
             var length = originalArray.Length;

--- a/src/DeepCopy/ArrayCopier.cs
+++ b/src/DeepCopy/ArrayCopier.cs
@@ -4,14 +4,29 @@ namespace DeepCopy
 {
     internal static class ArrayCopier
     {
-        internal static T[] CopyArrayRank1<T>(T[] originalArray, CopyContext context)
+        internal static T[] CopyArrayRank1<T>(T[] originalArray, CopyContext context) where T: class 
         {
-            if (context.TryGetCopy(originalArray, out var existingCopy)) return (T[])existingCopy;
-
+            if (context.TryGetCopy(originalArray, out var existingCopy)) return (T[]) existingCopy;
             var length = originalArray.Length;
             var result = new T[length];
             context.RecordCopy(originalArray, result);
-            for (var i = 0; i < length; i++) result[i] = CopierGenerator<T>.Copy(originalArray[i], context);
+            for (var i = 0; i < length; i++)
+            {
+                var original = originalArray[i];
+                if (original != null)
+                {
+                    if (context.TryGetCopy(original, out var existingElement))
+                    {
+                        result[i] = (T) existingElement;
+                    }
+                    else
+                    {
+                        var copy = CopierGenerator<T>.Copy(original, context);
+                        context.RecordCopy(original, copy);
+                        result[i] = copy;
+                    }
+                }
+            }
             return result;
         }
 
@@ -23,7 +38,24 @@ namespace DeepCopy
             var lenJ = originalArray.GetLength(1);
             var result = new T[lenI, lenJ];
             context.RecordCopy(originalArray, result);
-            for (var i = 0; i < lenI; i++) for (var j = 0; j < lenJ; j++) result[i, j] = CopierGenerator<T>.Copy(originalArray[i, j], context);
+            for (var i = 0; i < lenI; i++)
+            for (var j = 0; j < lenJ; j++)
+            {
+                var original = originalArray[i, j];
+                if (original != null)
+                {
+                    if (context.TryGetCopy(original, out var existingElement))
+                    {
+                        result[i, j] = (T) existingElement;
+                    }
+                    else
+                    {
+                        var copy = CopierGenerator<T>.Copy(original, context);
+                        context.RecordCopy(original, copy);
+                        result[i, j] = copy;
+                    }
+                }
+            }
             return result;
         }
 
@@ -50,23 +82,25 @@ namespace DeepCopy
             return result;
         }
 
-        internal static T CopyArray<T>(T original, CopyContext context)
+        internal static T CopyArray<T>(T array, CopyContext context)
         {
-            if (context.TryGetCopy(original, out var existingCopy)) return (T)existingCopy;
+            if (context.TryGetCopy(array, out var existingCopy)) return (T)existingCopy;
 
-            var originalArray = original as Array;
-            if (originalArray == null) throw new InvalidCastException($"Cannot cast non-array type {original?.GetType()} to Array.");
-            var elementType = original.GetType().GetElementType();
+            var originalArray = array as Array;
+            if (originalArray == null) throw new InvalidCastException($"Cannot cast non-array type {array?.GetType()} to Array.");
+            var elementType = array.GetType().GetElementType();
             
             var rank = originalArray.Rank;
             var lengths = new int[rank];
             for (var i = 0; i < rank; i++)
+            {
                 lengths[i] = originalArray.GetLength(i);
+            }
 
             var copyArray = Array.CreateInstance(elementType, lengths);
             context.RecordCopy(originalArray, copyArray);
 
-            if (DeepCopier.CopyPolicy.IsShallowCopyable(elementType))
+            if (DeepCopier.CopyPolicy.IsImmutable(elementType))
             {
                 Array.Copy(originalArray, copyArray, originalArray.Length);
             }
@@ -75,8 +109,9 @@ namespace DeepCopy
             var sizes = new int[rank];
             sizes[rank - 1] = 1;
             for (var k = rank - 2; k >= 0; k--)
+            {
                 sizes[k] = sizes[k + 1] * lengths[k + 1];
-
+            }
             for (var i = 0; i < originalArray.Length; i++)
             {
                 var k = i;
@@ -86,8 +121,20 @@ namespace DeepCopy
                     k = k - offset * sizes[n];
                     index[n] = offset;
                 }
-
-                copyArray.SetValue(DeepCopier.Copy(originalArray.GetValue(index), context), index);
+                var original = originalArray.GetValue(index);
+                if (original != null)
+                {
+                    if (context.TryGetCopy(original, out var existingElement))
+                    {
+                        copyArray.SetValue(existingElement, index);
+                    }
+                    else
+                    {
+                        var copy = DeepCopier.Copy(originalArray.GetValue(index), context);
+                        context.RecordCopy(original, copy);
+                        copyArray.SetValue(copy, index);
+                    }
+                }
             }
 
             return (T)(object)copyArray;

--- a/src/DeepCopy/CopierGenerator.cs
+++ b/src/DeepCopy/CopierGenerator.cs
@@ -167,7 +167,7 @@ namespace DeepCopy
                     }
                     else
                     {
-                        methodInfo = DeepCopier.MethodInfos.CopyArrayRank1Class;
+                        methodInfo = DeepCopier.MethodInfos.CopyArrayRank1;
                     }
                     break;
                 case 2:

--- a/src/DeepCopy/CopyPolicy.cs
+++ b/src/DeepCopy/CopyPolicy.cs
@@ -92,7 +92,7 @@ namespace DeepCopy
             {                
                 var copyableFields = GetCopyableFields(type);
                 var queue = new Queue<FieldInfo>(copyableFields);
-                var duplicateCheck = new HashSet<Type>(AssignableFromEqualityComparer.Instance);
+                var duplicateCheck = new HashSet<Type>(AssignableFromEqualityComparer.Instance) {type}; // add root
                 while (queue.Count > 0)
                 {
                     var current = queue.Dequeue();

--- a/src/DeepCopy/MethodInfos.cs
+++ b/src/DeepCopy/MethodInfos.cs
@@ -36,7 +36,7 @@ namespace DeepCopy
         public readonly MethodInfo GetTypeFromHandle;
 
         public readonly MethodInfo CopyArrayRank1Shallow;
-        public readonly MethodInfo CopyArrayRank1;
+        public readonly MethodInfo CopyArrayRank1Class;
 
         public readonly MethodInfo CopyArrayRank2Shallow;
         public readonly MethodInfo CopyArrayRank2;
@@ -50,7 +50,7 @@ namespace DeepCopy
             this.RecordObject = GetActionCall((CopyContext ctx) => ctx.RecordCopy(default(object), default(object)));
 
             this.CopyArrayRank1Shallow = GetFuncCall(() => ArrayCopier.CopyArrayRank1Shallow(default(object[]), default(CopyContext))).GetGenericMethodDefinition();
-            this.CopyArrayRank1 = GetFuncCall(() => ArrayCopier.CopyArrayRank1(default(object[]), default(CopyContext))).GetGenericMethodDefinition();
+            this.CopyArrayRank1Class = GetFuncCall(() => ArrayCopier.CopyArrayRank1(default(object[]), default(CopyContext))).GetGenericMethodDefinition();
 
             this.CopyArrayRank2Shallow = GetFuncCall(() => ArrayCopier.CopyArrayRank2Shallow(default(object[,]), default(CopyContext))).GetGenericMethodDefinition();
             this.CopyArrayRank2 = GetFuncCall(() => ArrayCopier.CopyArrayRank2(default(object[,]), default(CopyContext))).GetGenericMethodDefinition();

--- a/src/DeepCopy/MethodInfos.cs
+++ b/src/DeepCopy/MethodInfos.cs
@@ -36,7 +36,7 @@ namespace DeepCopy
         public readonly MethodInfo GetTypeFromHandle;
 
         public readonly MethodInfo CopyArrayRank1Shallow;
-        public readonly MethodInfo CopyArrayRank1Class;
+        public readonly MethodInfo CopyArrayRank1;
 
         public readonly MethodInfo CopyArrayRank2Shallow;
         public readonly MethodInfo CopyArrayRank2;
@@ -50,7 +50,7 @@ namespace DeepCopy
             this.RecordObject = GetActionCall((CopyContext ctx) => ctx.RecordCopy(default(object), default(object)));
 
             this.CopyArrayRank1Shallow = GetFuncCall(() => ArrayCopier.CopyArrayRank1Shallow(default(object[]), default(CopyContext))).GetGenericMethodDefinition();
-            this.CopyArrayRank1Class = GetFuncCall(() => ArrayCopier.CopyArrayRank1(default(object[]), default(CopyContext))).GetGenericMethodDefinition();
+            this.CopyArrayRank1 = GetFuncCall(() => ArrayCopier.CopyArrayRank1(default(object[]), default(CopyContext))).GetGenericMethodDefinition();
 
             this.CopyArrayRank2Shallow = GetFuncCall(() => ArrayCopier.CopyArrayRank2Shallow(default(object[,]), default(CopyContext))).GetGenericMethodDefinition();
             this.CopyArrayRank2 = GetFuncCall(() => ArrayCopier.CopyArrayRank2(default(object[,]), default(CopyContext))).GetGenericMethodDefinition();

--- a/test/DeepCopy.Benchmarks/GetCloneBenchmarks.cs
+++ b/test/DeepCopy.Benchmarks/GetCloneBenchmarks.cs
@@ -23,7 +23,7 @@ namespace DeepCopy.Benchmarks
                 ULong = 1516524352UL,
                 Double = 1235.1235762,
                 Float = 1.333F,
-                String = "Lorem ipsum ...",
+                String = "Lorem ipsum ..."
             };
 
             this._listOfInts = Enumerable.Range(0, 10000).ToList();

--- a/test/DeepCopy.UnitTests/BenchmarkTests.cs
+++ b/test/DeepCopy.UnitTests/BenchmarkTests.cs
@@ -9,16 +9,14 @@ namespace DeepCopy.UnitTests
     [Trait("TestCategory", "BenchmarkBVT")]
     public class BenchmarkTests
     {
-        private readonly ITestOutputHelper _outputHelper;
         private readonly SimpleClass _simpleClass;
         private readonly List<int> _listOfInts;
         private readonly List<SimpleClass> _listOfSimpleClassSameInstance;
         private readonly List<SimpleClass> _listOfSimpleClassDifferentInstances;
         private readonly List<SimpleStruct> _listOfSimpleStruct;
 
-        public BenchmarkTests(ITestOutputHelper outputHelper)
+        public BenchmarkTests()
         {
-            _outputHelper = outputHelper;
             this._simpleClass = new SimpleClass()
             {
                 Int = 10,
@@ -77,14 +75,6 @@ namespace DeepCopy.UnitTests
         [Fact]
         public int ListOfSimpleClassSameInstance_DeepCopy()
         {
-            //Stopwatch sw = new Stopwatch();
-            //sw.Start();
-            //for (int i = 0; i < 10000; i++)
-            //{
-            //    var clone = DeepCopier.Copy(this._listOfSimpleClassSameInstance);
-            //}
-            //sw.Stop();
-            //_outputHelper.WriteLine("Elapsed: {0}", sw.Elapsed.TotalMilliseconds);
             var clone = DeepCopier.Copy(this._listOfSimpleClassSameInstance);
             return clone.Count;
         }

--- a/test/DeepCopy.UnitTests/BenchmarkTests.cs
+++ b/test/DeepCopy.UnitTests/BenchmarkTests.cs
@@ -31,8 +31,8 @@ namespace DeepCopy.UnitTests
             this._listOfInts = Enumerable.Range(0, 10000).ToList();
 
             this._listOfSimpleClassSameInstance = Enumerable.Repeat(this._simpleClass, 10000).ToList();
-            this._listOfSimpleClassDifferentInstances = Enumerable.Range(0, 10000).Select(x => new SimpleClass() {Int = x}).ToList();
-            this._listOfSimpleStruct = Enumerable.Range(0, 10000).Select(x => new SimpleStruct() {Int = x}).ToList();
+            this._listOfSimpleClassDifferentInstances = Enumerable.Range(0, 10000).Select(x => new SimpleClass() { Int = x }).ToList();
+            this._listOfSimpleStruct = Enumerable.Range(0, 10000).Select(x => new SimpleStruct() { Int = x }).ToList();
         }
 
         public class SimpleClassBase
@@ -59,38 +59,48 @@ namespace DeepCopy.UnitTests
         }
 
         [Fact]
-        public int SimpleClass_DeepCopy()
+        public void SimpleClass_DeepCopy()
         {
             var clone = DeepCopier.Copy(this._simpleClass);
-            return clone.Int;
+            Assert.NotSame(clone, this._simpleClass);
         }
 
         [Fact]
-        public int ListOfInts_DeepCopy()
+        public void ListOfInts_DeepCopy()
         {
             var clone = DeepCopier.Copy(this._listOfInts);
-            return clone.Count;
+            Assert.NotSame(clone, this._listOfInts);
         }
 
         [Fact]
-        public int ListOfSimpleClassSameInstance_DeepCopy()
+        public void ListOfSimpleClassSameInstance_DeepCopy()
         {
             var clone = DeepCopier.Copy(this._listOfSimpleClassSameInstance);
-            return clone.Count;
+            Assert.NotSame(clone, this._listOfSimpleClassSameInstance);
+            var firstInstance = clone[0];
+            for (int i = 1; i < clone.Count; i++)
+            {
+                Assert.Same(firstInstance, clone[i]);
+            }
         }
 
         [Fact]
-        public int ListOfSimpleClassDifferentInstances_DeepCopy()
+        public void ListOfSimpleClassDifferentInstances_DeepCopy()
         {
             var clone = DeepCopier.Copy(this._listOfSimpleClassDifferentInstances);
-            return clone.Count;
+            Assert.NotSame(clone, this._listOfSimpleClassDifferentInstances);
+            var firstInstance = clone[0];
+            for (int i = 1; i < clone.Count; i++)
+            {
+                Assert.NotSame(firstInstance, clone[i]);
+            }
         }
 
         [Fact]
-        public int ListOfStruct_DeepCopy()
+        public void ListOfStruct_DeepCopy()
         {
             var clone = DeepCopier.Copy(this._listOfSimpleStruct);
-            return clone.Count;
+            Assert.NotSame(clone, this._listOfSimpleClassDifferentInstances);
         }
     }
 }

--- a/test/DeepCopy.UnitTests/BenchmarkTests.cs
+++ b/test/DeepCopy.UnitTests/BenchmarkTests.cs
@@ -1,20 +1,24 @@
 ﻿using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace DeepCopy.UnitTests
 {
     [Trait("TestCategory", "BenchmarkBVT")]
     public class BenchmarkTests
     {
+        private readonly ITestOutputHelper _outputHelper;
         private readonly SimpleClass _simpleClass;
         private readonly List<int> _listOfInts;
         private readonly List<SimpleClass> _listOfSimpleClassSameInstance;
         private readonly List<SimpleClass> _listOfSimpleClassDifferentInstances;
         private readonly List<SimpleStruct> _listOfSimpleStruct;
 
-        public BenchmarkTests()
+        public BenchmarkTests(ITestOutputHelper outputHelper)
         {
+            _outputHelper = outputHelper;
             this._simpleClass = new SimpleClass()
             {
                 Int = 10,
@@ -73,6 +77,14 @@ namespace DeepCopy.UnitTests
         [Fact]
         public int ListOfSimpleClassSameInstance_DeepCopy()
         {
+            //Stopwatch sw = new Stopwatch();
+            //sw.Start();
+            //for (int i = 0; i < 10000; i++)
+            //{
+            //    var clone = DeepCopier.Copy(this._listOfSimpleClassSameInstance);
+            //}
+            //sw.Stop();
+            //_outputHelper.WriteLine("Elapsed: {0}", sw.Elapsed.TotalMilliseconds);
             var clone = DeepCopier.Copy(this._listOfSimpleClassSameInstance);
             return clone.Count;
         }

--- a/test/DeepCopy.UnitTests/CopyTests.cs
+++ b/test/DeepCopy.UnitTests/CopyTests.cs
@@ -271,6 +271,39 @@ namespace DeepCopy.UnitTests
             Assert.Equal(result, original);
         }
 
+        [Fact]
+        public void CanCopyCyclicObjectsWithChildren()
+        {
+            var original = new CyclicPocoWithChildren();
+            original.Children.Add(original);
+
+            var result = DeepCopier.Copy(original);
+            Assert.NotSame(original, result);
+            Assert.Same(result, result.Children[0]);
+        }
+
+        [Fact]
+        public void CanCopyCyclicObjectsWithSibling()
+        {
+            var original = new CyclicPocoWithSibling();
+            original.Sibling = original;
+
+            var result = DeepCopier.Copy(original);
+            Assert.NotSame(original, result);
+            Assert.Same(result, result.Sibling);
+        }
+
+        [Fact]
+        public void CanCopyCyclicObjectsWithBaseSibling()
+        {
+            var original = new CyclicPocoWithBaseSibling();
+            original.BaseSibling = original;
+
+            var result = DeepCopier.Copy(original);
+            Assert.NotSame(original, result);
+            Assert.Same(result, result.BaseSibling);
+        }
+
         public static IEnumerable<object[]> ImmutableTestData()
         {
             yield return new object[] { 5m };
@@ -332,6 +365,26 @@ namespace DeepCopy.UnitTests
             }
 
             public object GetReference() => this.reference;
+        }
+
+        private class CyclicPocoWithChildren : CyclicPocoBaseSibling
+        {
+            public List<CyclicPocoWithChildren> Children { get; set; } = new List<CyclicPocoWithChildren>();
+        }
+
+        private class CyclicPocoWithSibling : CyclicPocoBaseSibling
+        {
+            public CyclicPocoWithSibling Sibling { get; set; }
+        }
+
+        private class CyclicPocoWithBaseSibling : CyclicPocoBaseSibling
+        {
+            public CyclicPocoBaseSibling BaseSibling { get; set; }
+        }
+
+        private class CyclicPocoBaseSibling
+        {
+            public string Name { get; set; }
         }
     }
 }

--- a/test/DeepCopy.UnitTests/CopyTests.cs
+++ b/test/DeepCopy.UnitTests/CopyTests.cs
@@ -33,6 +33,83 @@ namespace DeepCopy.UnitTests
         }
 
         [Fact]
+        public void CanCopyArraysTwoDimensional()
+        {
+            var original = new object[][] {new object[] {123, "hello!"}, new object[] {123, "hello!"}};
+            var result = DeepCopier.Copy(original);
+            Assert.Equal(original, result);
+            Assert.NotSame(original, result);
+        }
+
+        [Fact]
+        public void CanCopyArraysRank3()
+        {
+            var original = new object[,,] { { { "Hello", 2, "World" }, { 300.0f, "World", 33 } }, { { 92, 5.0m, 135 }, { 30, true, 3 } } };
+            var result = DeepCopier.Copy(original);
+            Assert.Equal(original, result);
+            Assert.NotSame(original, result);
+        }
+
+        [Fact]
+        public void CanCopyArraysRank3WithImmutable()
+        {
+            var immutable = new ImmutablePoco();
+            var original = new object[,,]
+            {
+                {
+                    {"Hello", 2, immutable},
+                    {300.0f, immutable, 33}
+                },
+                {
+                    {immutable, 5.0m, 135},
+                    {30, immutable, 3}
+                }
+            };
+            var result = DeepCopier.Copy(original);
+            Assert.Equal(original, result);
+            Assert.NotSame(original, result);
+            Assert.Same(immutable, result[0, 0, 2]);
+            Assert.Same(immutable, result[0, 1, 1]);
+            Assert.Same(immutable, result[1, 0, 0]);
+            Assert.Same(immutable, result[1, 1, 1]);
+        }
+
+        [Fact]
+        public void CanCopyThreeDimensionalArrays()
+        {
+            var original = new object[][][]
+            {
+                new object[][]
+                {
+                    new object[] {123, "hello!"}
+                },
+                new object[][]
+                {
+                    new object[] {123, "hello!", "world"},
+                    new object[] {123, "hello!"}
+                },
+            };
+            var result = DeepCopier.Copy(original);
+            Assert.Equal(original, result);
+            Assert.NotSame(original, result);
+        }
+
+        [Fact]
+        public void CanCopyJaggedMultidimensionalArrays()
+        {
+            var original = new object[3][,]
+            {
+                new object[,] {{123, "hello!"}, {5, 7}},
+                new object[,] {{456, "world"}, {4, 6}, {"hello", "world"}},
+                new object[,] {{789, "universe"}, {99, 88}, {0, 9}}
+            };
+
+            var result = DeepCopier.Copy(original);
+            Assert.Equal(original, result);
+            Assert.NotSame(original, result);
+        }
+
+        [Fact]
         public void CanCopyCollections()
         {
             {
@@ -59,7 +136,16 @@ namespace DeepCopy.UnitTests
         }
 
         [Fact]
-        public void CanCopyTwoDimensionalArrays()
+        public void CanCopyPrimitiveArraysRank3()
+        {
+            var original = new int[,,] { { { 12, 2, 35 }, { 300, 78, 33 } }, { { 92, 42, 135 }, { 30, 7, 3 } } };
+            var result = DeepCopier.Copy(original);
+            Assert.Equal(original, result);
+            Assert.NotSame(original, result);
+        }
+
+        [Fact]
+        public void CanCopyPrimitiveTwoDimensionalArraysShallow()
         {
             var original = new int[][]
             {
@@ -73,7 +159,7 @@ namespace DeepCopy.UnitTests
         }
 
         [Fact]
-        public void CanCopyThreeDimensionalArrays()
+        public void CanCopyPrimitiveThreeDimensionalArrays()
         {
             var original = new int[][][]
             {
@@ -93,7 +179,7 @@ namespace DeepCopy.UnitTests
         }
 
         [Fact]
-        public void CanCopyJaggedMultidimensionalArrays()
+        public void CanCopyPrimitiveJaggedMultidimensionalArrays()
         {
             var original = new int[3][,]
             {


### PR DESCRIPTION
This follows the logic described in #6.

1. Need to do manually tracking for arrays in the arraycopier
2. Removed ShallowCopyable and replaced with IsImmutable where necessary
3. Removed the immutable declarations in the constructor as they are now covered by the logic
4. Added an enum value Tracking to decide which ones need tracking
5. Added several more tests (and actually made the benchmark tests assert) for array tests and tracking logic to improve test coverage

The main rule logic from #6 remains, it is split into two parts:
1. The check for immutability
2. The check for tracking, including the previously discussed recursion to find mutable fields which might be reused elsewhere in the object graph.

I'm not really happy with the manual array stuff but couldn't find a way around it.
My gut tells me that we actually still track more than necessary.
But the simple copy of the simple class is now faster as it does not need tracking. I don't really know why the ``ListOfSimpleClassSameInstance_DeepCopy`` is now roughly 30% faster.

As for benchmarks:
Pre:
``` ini

BenchmarkDotNet=v0.10.10, OS=Windows 10 Redstone 1 [1607, Anniversary Update] (10.0.14393.1884)
Processor=Intel Xeon CPU E5-1620 0 3.60GHz, ProcessorCount=8
Frequency=3507174 Hz, Resolution=285.1299 ns, Timer=TSC
.NET Core SDK=2.0.3
  [Host]     : .NET Core 2.0.3 (Framework 4.6.25815.02), 64bit RyuJIT
  DefaultJob : .NET Core 2.0.3 (Framework 4.6.25815.02), 64bit RyuJIT


```
|                                       Method |           Mean |          Error |         StdDev |    Gen 0 |    Gen 1 |    Gen 2 | Allocated |
|--------------------------------------------- |---------------:|---------------:|---------------:|---------:|---------:|---------:|----------:|
|                         SimpleClass_CloneExt |       230.3 ns |      1.7621 ns |      1.6483 ns |   0.0532 |        - |        - |     280 B |
|                          ListOfInts_CloneExt |     4,320.5 ns |     49.3586 ns |     41.2166 ns |   7.6294 |   0.7629 |        - |   40280 B |
|       ListOfSimpleClassSameInstance_CloneExt |   652,194.8 ns |  6,567.6125 ns |  5,822.0169 ns |  14.6484 |   1.9531 |        - |   80384 B |
| ListOfSimpleClassDifferentInstances_CloneExt | 2,614,687.8 ns | 21,116.0982 ns | 18,718.8692 ns | 218.7500 | 218.7500 | 218.7500 | 1662112 B |
|                        ListOfStruct_CloneExt |   585,426.4 ns | 11,405.3051 ns | 10,668.5284 ns |  49.8047 |  49.8047 |  49.8047 |  160328 B |
|                         SimpleClass_DeepCopy |       114.0 ns |      0.7676 ns |      0.7180 ns |   0.0122 |        - |        - |      64 B |
|                          ListOfInts_DeepCopy |     4,453.4 ns |     38.6745 ns |     36.1761 ns |   7.6294 |   0.7629 |        - |   40064 B |
|       ListOfSimpleClassSameInstance_DeepCopy |   372,061.1 ns |  3,869.6505 ns |  3,231.3331 ns |  15.1367 |   2.4414 |        - |   80128 B |
| ListOfSimpleClassDifferentInstances_DeepCopy |   816,057.1 ns | 10,102.7701 ns |  8,436.2698 ns | 124.0234 |  58.5938 |        - |  720064 B |
|                        ListOfStruct_DeepCopy |    61,295.8 ns |    363.7500 ns |    340.2520 ns |  49.9268 |  49.9268 |  49.9268 |  160064 B |


Post:
``` ini

BenchmarkDotNet=v0.10.10, OS=Windows 10 Redstone 1 [1607, Anniversary Update] (10.0.14393.1884)
Processor=Intel Xeon CPU E5-1620 0 3.60GHz, ProcessorCount=8
Frequency=3507174 Hz, Resolution=285.1299 ns, Timer=TSC
.NET Core SDK=2.0.3
  [Host]     : .NET Core 2.0.3 (Framework 4.6.25815.02), 64bit RyuJIT
  DefaultJob : .NET Core 2.0.3 (Framework 4.6.25815.02), 64bit RyuJIT


```
|                                       Method |            Mean |          Error |         StdDev |    Gen 0 |    Gen 1 |    Gen 2 | Allocated |
|--------------------------------------------- |----------------:|---------------:|---------------:|---------:|---------:|---------:|----------:|
|                         SimpleClass_CloneExt |       225.06 ns |      1.7111 ns |      1.5169 ns |   0.0532 |        - |        - |     280 B |
|                          ListOfInts_CloneExt |     4,349.84 ns |     85.4299 ns |    140.3638 ns |   7.6294 |   0.7629 |        - |   40280 B |
|       ListOfSimpleClassSameInstance_CloneExt |   663,234.23 ns | 10,154.0308 ns |  9,001.2830 ns |  14.6484 |   1.9531 |        - |   80384 B |
| ListOfSimpleClassDifferentInstances_CloneExt | 2,607,385.28 ns | 22,859.8981 ns | 21,383.1608 ns | 218.7500 | 218.7500 | 218.7500 | 1662112 B |
|                        ListOfStruct_CloneExt |   567,527.10 ns |  3,518.6598 ns |  3,119.1999 ns |  49.8047 |  49.8047 |  49.8047 |  160328 B |
|                         SimpleClass_DeepCopy |        39.63 ns |      0.2761 ns |      0.2448 ns |   0.0122 |        - |        - |      64 B |
|                          ListOfInts_DeepCopy |     4,288.97 ns |      9.7245 ns |      8.6205 ns |   7.6294 |   0.7629 |        - |   40064 B |
|       ListOfSimpleClassSameInstance_DeepCopy |   258,315.65 ns |    563.1187 ns |    470.2295 ns |  15.1367 |   2.4414 |        - |   80128 B |
| ListOfSimpleClassDifferentInstances_DeepCopy |   818,371.09 ns |  6,458.3902 ns |  6,041.1817 ns | 125.0000 |  58.5938 |        - |  720064 B |
|                        ListOfStruct_DeepCopy |    60,032.40 ns |    170.9896 ns |    159.9438 ns |  49.9878 |  49.9878 |  49.9878 |  160064 B |